### PR TITLE
Fix WX-78 drones and portable storage being unusable

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -9,7 +9,7 @@ author = "rezecib, Sarcen"
 
 --A version number so you can ask people if they are running an old version of your mod.
 --In DST this is also used to determine compatibility for joining servers
-version = "1.7.5"
+version = "1.7.6"
 
 forumthread = ""
 

--- a/modmain.lua
+++ b/modmain.lua
@@ -700,13 +700,26 @@ AddClassPostConstruct("widgets/mapwidget", function(MapWidget)
 		-- Begin copy-pasted code (small edits to match modmain environment)
 		if GLOBAL.TheInput:IsControlPressed(GLOBAL.CONTROL_PRIMARY) then
 			local pos = GLOBAL.TheInput:GetScreenPosition()
-			if self.lastpos then
+			if self.lastpos and (pos.x ~= self.lastpos.x or pos.y ~= self.lastpos.y) then
+				local dx = pos.x - self.lastpos.x
+				local dy = pos.y - self.lastpos.y
+				-- WX-78 drones & portable storage set MapScreen:SetHandleLmbUp(true),
+				-- which calls minimap:StartDragThreshold so a stationary click isn't
+				-- swallowed as a pan. Honor the flag: below threshold, skip Offset
+				-- (otherwise OnMinimapMoved cancels the LMB-up action and the
+				-- MAPSCOUT_MAP / MAPDELIVER_MAP click is lost).
+				if self.dragthreshold then
+					local dsq = dx * dx + dy * dy
+					local threshold = self.dragthreshold * math.min(GLOBAL.TheSim:GetScreenSize())
+					if dsq < threshold * threshold then
+						return
+					end
+					self:CancelDragThreshold()
+				end
 				local scale = 0.25
-				local dx = scale * ( pos.x - self.lastpos.x )
-				local dy = scale * ( pos.y - self.lastpos.y )
-				self:Offset( dx, dy ) --#rezecib changed this so we can capture offsets
+				self:Offset( scale * dx, scale * dy ) --#rezecib changed this so we can capture offsets
 			end
-			
+
 			self.lastpos = pos
 		else
 			self.lastpos = nil


### PR DESCRIPTION
## Problem

With Global Positions enabled, the new WX-78 units (scout drones, portable storage, delivery drones) can't be used — clicking on the map to dispatch them does nothing.

## Cause

The recent WX-78 update added a drag-threshold step to `MapWidget`. When the map queues an LMB action (MAPSCOUT_MAP / MAPDELIVER_MAP) it calls `MapScreen:SetHandleLmbUp(true)` → `minimap:StartDragThreshold(0.02)` so a stationary click isn't swallowed as a pan. Vanilla `MapWidget:OnUpdate` now checks `self.dragthreshold` and returns early when motion is below threshold.

This mod's `MapWidget:OnUpdate` override in `modmain.lua` didn't check that flag, so the first sub-pixel of cursor motion called `self:Offset(...)` → `mapscreen:OnMinimapMoved()` → `SetHandleLmbUp(false)`, and the click was dropped before the action could fire.

## Fix

Port the vanilla threshold check into the override. Below threshold: skip `Offset` and leave `lastpos` pinned so the next frame measures cumulative delta. Above threshold: `CancelDragThreshold` and pan as before. Pan scale (`0.25`) and the existing offset-tracking hook are unchanged.

## Test

Enable the mod on a WX-78 world:
- Deploy a scout drone, open the map, click a destination → drone flies there (before fix: click ignored).
- Right-click a portable storage / delivery drone to open the map, click a destination → unit is dispatched (before fix: click ignored).
- Normal map panning (LMB drag) still works.